### PR TITLE
Add date-based anchor to individual event blocks.

### DIFF
--- a/layouts/shortcodes/events-list.html
+++ b/layouts/shortcodes/events-list.html
@@ -1,7 +1,11 @@
 <div class="events-list">
 {{ range $.Site.Data.events }}
-    <div class="event-block" style="margin-bottom: 2rem;" data-event-date="{{ .start }}">
-        <h3 style="margin-bottom: 5px;" >{{ .title }}</h3>
+    <div class="event-block" style="margin-bottom: 2rem;"
+         data-event-date="{{ .start }}"
+         id="{{ time.Format "2006-01-02" (time.AsTime .start)}}_{{ hash.FNV32a .title | printf "%x" }}">
+        <h3 style="margin-bottom: 5px;">
+            {{ .title }}
+        </h3>
         <div>{{ safeHTML .description }}</div>
         <div style="margin-top: 0.6rem">
         <b>Time: </b>


### PR DESCRIPTION
This allows for generating shortlinks to individual events using an anchor, e.g. "2024-06-06_d3d3c5a2".